### PR TITLE
kubectl: install latest krew package manager on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,16 @@ RUN USER=docker \
     && mkdir -p /etc/fixuid \
     && printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
 
-# Set the default user to run commands
+# Set the default user to run commands, everything RUN after this line will be as normal user!
 USER docker:docker
+
+# Install Krew kubectl plugin manager
+RUN cd $HOME && mkdir tmp-krew && cd ./tmp-krew \
+    && wget https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.tar.gz \
+    && tar zxvf krew.tar.gz \
+    && ./krew-linux_amd64 install krew \
+    && cd ../ && rm -rf tmp-krew
+ENV PATH="/home/clitools/.krew/bin:${PATH}"
 
 # Install latest unittest Helm plugin as user
 RUN helm plugin install https://github.com/quintush/helm-unittest \


### PR DESCRIPTION
Installs a plugin package manager for kubectl, so that we can add useful kubectl plugins effortless.

https://github.com/kubernetes-sigs/krew-index/blob/master/plugins.md
