### PR TITLE
kubectl: install useful plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,4 +83,17 @@ ENV PATH="/home/clitools/.krew/bin:${PATH}"
 RUN helm plugin install https://github.com/quintush/helm-unittest \
     && rm -rf /tmp/*
 
+# Install kubectl plugins with Krew
+RUN kubectl krew update \
+    && kubectl krew install cert-manager \
+    && kubectl krew install deprecations \
+    && kubectl krew install neat \
+    && kubectl krew install np-viewer \
+    && kubectl krew install popeye \
+    && kubectl krew install prompt \
+    && kubectl krew install resource-capacity \
+    && kubectl krew install rolesum \
+    && kubectl krew install score \
+    && kubectl krew install tree
+
 ENTRYPOINT ["fixuid", "-q"]


### PR DESCRIPTION
List of plugins available from krew:
https://github.com/kubernetes-sigs/krew-index/blob/master/plugins.md

This PR will install the following kubectl plugins:
- https://cert-manager.io/docs/usage/kubectl-plugin/
- https://github.com/rikatz/kubepug
- https://github.com/itaysk/kubectl-neat
- https://github.com/runoncloud/kubectl-np-viewer
- https://popeyecli.io/
- https://github.com/jordanwilson230/kubectl-plugins/tree/krew#kubectl-prompt
- https://github.com/robscott/kube-capacity
- https://github.com/Ladicle/kubectl-rolesum
- https://github.com/zegl/kube-score
- https://github.com/ahmetb/kubectl-tree

⚠️  Reviewers, please inspect each plugin _**before approving**_ for any oddities, or if you are unsure that we should add said plugin!